### PR TITLE
Total rewrite

### DIFF
--- a/congestion-control-charter.md
+++ b/congestion-control-charter.md
@@ -1,10 +1,9 @@
 # Congestion Control Working Group Charter (CCWG)
 
-
 RFC 5033 describes a Best Current Practice to evaluate new congestion control
 algorithms as Experimental or Proposed Standard RFCs. TCP was the dominant
 consumer of this work, and proposals were typically discussed in research
-groups (for example, the Internet Congestion Control Research Group - ICCRG).
+groups, for example the Internet Congestion Control Research Group (ICCRG).
 
 Since RFC 5033 was published, many conditions have changed. Congestion control
 algorithm proponents now often have the opportunity to test and deploy at scale
@@ -14,21 +13,36 @@ in specialized use cases such as data centers and real-time protocols. Finally,
 the community has gained much more experience with indications of congestion
 beyond packet loss.
 
-The Congestion Control Working Group will review some of the impediments to 
+The Congestion Control Working Group will review some of the impediments to
 congestion control work occurring in the IETF and can generalize transports
-from TCP to all of the relevant transport protocols. This will inform a revision
-of RFC 5033 that encourages IETF review of congestion control proposals and
-standardization of mature congestion control algorithms.
+from TCP to all of the relevant transport protocols. This will inform a
+revision of RFC 5033 that encourages IETF review of congestion control
+proposals and standardization of mature congestion control algorithms.
 
-The congestion control expertise in the working group would also make it a
-natural venue to take on other work related to indications of congestion (such
-as delay), queueing algorithms, rate pacing, interaction with other layers,
-etc. In particular, it could address congestion control algorithms with
+The congestion control expertise in the working group also makes it a natural
+venue to take on other work related to indications of congestion such as delay,
+queuing algorithms, rate pacing, multipath, interaction with other layers,
+among others. In particular, it can address congestion control algorithms with
 empirical evidence of safety and stated intent to deploy by major
-implementations. The working group is intended to be a home for such work, should
-it arise, if not suitable for the IRTF. It is chartered to consider proposals in
-this space, and given consensus to adopt, seek an immediate recharter regardless
-of the status of the initial deliverable.
+implementations. The working group is intended to be a home for such work, and
+it is chartered to adopt proposals in this space regardless of the status of
+the initial deliverable.
+
+The group will coordinate closely with other relevant working and research
+groups, including ICCRG, TCPM, QUIC, and TSVWG. Documents in CCWG will remain
+as transport protocol agnostic as possible, but they may have short specific
+instructions, such as header options or parameter formats, for one or more
+protocols. Documents that are wholly specific to mechanisms in a single
+protocol will remain in the maintenance working group for that protocol.
+
+Algorithms proposed for Experimental status, in consultation with ICCRG, based
+on an assessment of their maturity and likelihood of near-term wide-scale
+deployment, are in scope.
+
+CCWG is not chartered to publish Informational RFCs documenting the state of
+congestion control in the Internet, including assessments of compliance with
+existing standards. Other venues, such as the IRTF, may be more appropriate for
+publishing such documents.
 
 Upon completion of its deliverables, the Congestion Control WG will close in 
 the absence of suitable proposals for further work.

--- a/congestion-control-charter.md
+++ b/congestion-control-charter.md
@@ -1,4 +1,4 @@
-Congestion Control Working Group Charter (CCWG)
+# Congestion Control Working Group Charter (CCWG)
 
 
 RFC 5033 describes a Best Current Practice to evaluate new congestion control

--- a/congestion-control-charter.txt
+++ b/congestion-control-charter.txt
@@ -1,10 +1,10 @@
-﻿Congestion Working Group Charter
+Congestion Control Working Group Charter (CCWG)
+
 
 RFC 5033 describes a Best Current Practice to evaluate new congestion control
 algorithms as Experimental or Proposed Standard RFCs. TCP was the dominant
 consumer of this work, and proposals were typically discussed in research
 groups (for example, the Internet Congestion Control Research Group - ICCRG).
-
 
 Since RFC 5033 was published, many conditions have changed. Congestion control
 algorithm proponents now often have the opportunity to test and deploy at scale
@@ -14,9 +14,8 @@ in specialized use cases such as data centers and real-time protocols. Finally,
 the community has gained much more experience with indications of congestion
 beyond packet loss.
 
-The Congestion working group will review some of the impediments to congestion
+The Congestion Control Working Group will review some of the impediments to congestion
 control work occurring in the IETF and can generalize transports
-
 from TCP to all of the relevant transport protocols. This will inform a revision
 of RFC 5033 that encourages IETF review of congestion control proposals and
 standardization of mature congestion control algorithms.
@@ -31,5 +30,5 @@ it arise, if not suitable for the IRTF. It is chartered to consider proposals in
 this space, and given consensus to adopt, seek an immediate recharter regardless
 of the status of the initial deliverable.
 
-Upon completion of its deliverables, the Congestion WG will close in the absence
+Upon completion of its deliverables, the Congestion Control WG will close in the absence
 of suitable proposals for further work.

--- a/congestion-control-charter.txt
+++ b/congestion-control-charter.txt
@@ -15,7 +15,8 @@ the community has gained much more experience with indications of congestion
 beyond packet loss.
 
 The Congestion working group will review some of the impediments to congestion
-control work occurring in the IETF, and can generalize transport in this area
+control work occurring in the IETF and can generalize transports
+
 from TCP to all of the relevant transport protocols. This will inform a revision
 of RFC 5033 that encourages IETF review of congestion control proposals and
 standardization of mature congestion control algorithms.

--- a/congestion-control-charter.txt
+++ b/congestion-control-charter.txt
@@ -26,7 +26,8 @@ natural venue to take on other work related to indications of congestion (such
 as delay), queueing algorithms, rate pacing, interaction with other layers,
 etc. In particular, it could address congestion control algorithms with
 empirical evidence of safety and stated intent to deploy by major
-implementation. The working group is intended to be a home for such work, should
+implementations. The working group is intended to be a home for such work, should
+
 it arise, if not suitable for the IRTF. It is chartered to consider proposals in
 this space, and given consensus to adopt, seek an immediate recharter regardless
 of the status of the initial deliverable.

--- a/congestion-control-charter.txt
+++ b/congestion-control-charter.txt
@@ -22,12 +22,12 @@ standardization of mature congestion control algorithms.
 The congestion control expertise in the working group would also make it a
 natural venue to take on other work related to indications of congestion (such
 as delay), queueing algorithms, rate pacing, interaction with other layers,
-etc. In particular, it could address congestion control algorithms mature enough
-for standardization. The working group is intended to be a home for such work,
-should it arise, if not suitable for the IRTF. It is chartered to consider
-proposals in this space, and given consensus to adopt, seek an immediate
-recharter regardless of the status of the initial deliverable.
+etc. In particular, it could address congestion control algorithms with
+empirical evidence of safety and stated intent to deploy by major
+implementation. The working group is intended to be a home for such work, should
+it arise, if not suitable for the IRTF. It is chartered to consider proposals in
+this space, and given consensus to adopt, seek an immediate recharter regardless
+of the status of the initial deliverable.
 
-Upon completion of its deliverables, the Congestion WG will close in the absence of
-
-suitable proposals for further work.
+Upon completion of its deliverables, the Congestion WG will close in the absence
+of suitable proposals for further work.

--- a/congestion-control-charter.txt
+++ b/congestion-control-charter.txt
@@ -1,85 +1,32 @@
-﻿CONGestion RESponse and Signaling Working Group Charter (CONGRESS)
+﻿Congestion Working Group Charter
 
-RFC 5033 describes a Best Current
-Practice to evaluate new congestion control algorithms as Experimental or
-Proposed Standard RFCs. TCP was the dominant
-consumer of this work, and proposals were typically discussed in research groups (for example, Internet Congestion Control Research Group - ICCRG).
+RFC 5033 describes a Best Current Practice to evaluate new congestion control
+algorithms as Experimental or Proposed Standard RFCs. TCP was the dominant
+consumer of this work, and proposals were typically discussed in research
+groups (for example, Internet Congestion Control Research Group - ICCRG).
 
+Since RFC 5033 was published, many conditions have changed. Congestion control
+algorithm proponents now often have the opportunity to test and deploy at scale
+without IETF review. The set of protocols using these algorithms has spread
+beyond TCP and SCTP to include DCCP, QUIC, and beyond. There is more interest
+in specialized use cases such as data centers and real-time protocols. Finally,
+the community has gained much more experience with indications of congestion
+beyond packet loss.
 
-Since RFC 5033 was published, many conditions have changed. Congestion control algorithm proponents
-now often have the opportunity to test and deploy at scale without IETF review. The
-set of protocols using these algorithms has spread beyond TCP and SCTP to
-include DCCP, QUIC, and beyond. There is more interest in specialized use cases
-such as data centers and real-time protocols. Finally, the community has gained
-much more experience with indications of congestion beyond packet loss.
+The Congestion working group will review some of the impediments to congestion
+control work occurring in the IETF, and can generalize transport in this area
+from TCP to all of the relevant transport protocols. This will inform a revision
+of RFC 5033 that encourages IETF review of congestion control proposals and
+standardization of mature congestion control algorithms.
 
-The CONGestion RESponse and Signaling working group (CONGRESS) can review some
-of the impediments to early congestion control work occurring in the IETF, and
-can generalize transport in this area from TCP to all of the relevant transport
-protocols. The congestion control expertise in the working group would also
-make it a natural venue to take on other work related to indications of
-congestion, such as delay, and potentially queueing algorithms.
+The congestion control expertise in the working group would also make it a
+natural venue to take on other work related to indications of congestion (such
+as delay), queueing algorithms, rate pacing, interaction with other layers,
+etc. In particular, it could address congestion control algorithms mature enough
+for standardization. The working group is intended to be a home for such work,
+should it arise, if not suitable for the IRTF. It is chartered to consider
+proposals in this space, and given consensus to adopt, seek an immediate
+recharter regardless of the status of the initial deliverable.
 
-CONGRESS is chartered to conduct a revision of RFC 5033. The working group should
-
-consider a revision that relaxes requirements to encourage more experiments in
-the IRTF/IETF. Adoption of standards-track congestion control algorithms should consider (1) empirical
-
-evidence of safety (for example - avoiding congestion collapse) and (2) stated intent to deploy by major transport
-implementations.
-
-CONGRESS is authorized to adopt work relating to Congestion Control and AQM without rechartering.
-
-This work may be ongoing in TCPM, CORE, ICCRG, or elsewhere, and if so,
-coordination is required to decide between adoption of the work and consultation
-on it, based on its maturity, the quality of relevant review in either venue,
-and its match with the CONGRESS adoption criteria to be enumerated in the
-RFC 5033 update. The following are specifically in scope:
-
-* Algorithms mature enough for standardization. CONGRESS may consider not
-only the open Internet, but also algorithms focused on other deployment models
-(e.g. datacenters and other controlled environments, reduced resource
-deployments such as IoT, and so on). Any adopted document must be clear about
-the domains to which its operation is restricted.
-
-* Algorithms proposed for Experimental status, in consultation with ICCRG, based
-on an assessment of their maturity and likelihood of near-term wide-scale
-deployment.
-
-* Multipath congestion control.
-
-* Active Queue Managment (AQM) and Fair Queueing (FQ) algorithms, in
-consultation with TSVWG, based on the available time and reviewing expertise in
-both groups.
-
-* Rate pacing, including bandwidth estimation techniques that inform it.
-
-* Tweaks to existing algorithms, such as Slow Start.
-
-* Techniques to address lower-layer alterations to packet timing or ordering.
-
-* New ways for endpoints to respond to both implicit and explicit congestion
-signals, including specification of explicit signals.
-
-* Progression of existing Informational or Experimental RFCs to higher maturity,
-if they meet the criteria.
-
-* Real-time, media adaptation algorithms for peer to peer communications
-
-* Operational guidance, in general, including advice to upper layers or new
-transport protocols. Examples include minimum frequency of feedback,
-counterproductive application retransmissions and multiple connections to the
-same host.
-
-Proposals that depend on the capabilities of a single transport protocol should
-generally remain in the maintenance working group for that protocol (i.e.,
-TCPM, QUIC, TSVWG). Documents in CONGRESS should remain as independent of
-transport protocol as possible, but they might have short specific instructions
-(e.g. a header option or parameter format) for one or more protocols.
-
-CONGRESS is not chartered to publish Informational RFCs documenting the state of
-congestion control in the Internet, including assessments of compliance with
-existing standards. Other venues, e.g., IRTF, may be more appropriate for
-publishing such documents.
-
-CONGRESS will not remain open simply “in case” further work comes along. 
+Upon completion of the deliverable, Congestion WG will close in the absence of
+suitable proposals for further work.

--- a/congestion-control-charter.txt
+++ b/congestion-control-charter.txt
@@ -14,8 +14,8 @@ in specialized use cases such as data centers and real-time protocols. Finally,
 the community has gained much more experience with indications of congestion
 beyond packet loss.
 
-The Congestion Control Working Group will review some of the impediments to congestion
-control work occurring in the IETF and can generalize transports
+The Congestion Control Working Group will review some of the impediments to 
+congestion control work occurring in the IETF and can generalize transports
 from TCP to all of the relevant transport protocols. This will inform a revision
 of RFC 5033 that encourages IETF review of congestion control proposals and
 standardization of mature congestion control algorithms.
@@ -30,5 +30,5 @@ it arise, if not suitable for the IRTF. It is chartered to consider proposals in
 this space, and given consensus to adopt, seek an immediate recharter regardless
 of the status of the initial deliverable.
 
-Upon completion of its deliverables, the Congestion Control WG will close in the absence
-of suitable proposals for further work.
+Upon completion of its deliverables, the Congestion Control WG will close in 
+the absence of suitable proposals for further work.

--- a/congestion-control-charter.txt
+++ b/congestion-control-charter.txt
@@ -27,7 +27,6 @@ as delay), queueing algorithms, rate pacing, interaction with other layers,
 etc. In particular, it could address congestion control algorithms with
 empirical evidence of safety and stated intent to deploy by major
 implementations. The working group is intended to be a home for such work, should
-
 it arise, if not suitable for the IRTF. It is chartered to consider proposals in
 this space, and given consensus to adopt, seek an immediate recharter regardless
 of the status of the initial deliverable.

--- a/congestion-control-charter.txt
+++ b/congestion-control-charter.txt
@@ -28,5 +28,6 @@ should it arise, if not suitable for the IRTF. It is chartered to consider
 proposals in this space, and given consensus to adopt, seek an immediate
 recharter regardless of the status of the initial deliverable.
 
-Upon completion of the deliverable, Congestion WG will close in the absence of
+Upon completion of its deliverables, the Congestion WG will close in the absence of
+
 suitable proposals for further work.

--- a/congestion-control-charter.txt
+++ b/congestion-control-charter.txt
@@ -3,7 +3,8 @@
 RFC 5033 describes a Best Current Practice to evaluate new congestion control
 algorithms as Experimental or Proposed Standard RFCs. TCP was the dominant
 consumer of this work, and proposals were typically discussed in research
-groups (for example, Internet Congestion Control Research Group - ICCRG).
+groups (for example, the Internet Congestion Control Research Group - ICCRG).
+
 
 Since RFC 5033 was published, many conditions have changed. Congestion control
 algorithm proponents now often have the opportunity to test and deploy at scale


### PR DESCRIPTION
The IESG feedback was that 

(1) they didn't like the very long enumeration of scope that was unrelated to the actual milestone
(2) they didn't like the name.

This PR changes the approach, narrowly chartering the WG to work on 5033bis, but encouraging a very rapid recharter as soon as there's further work it wants to adopt. There's no need to be precise about scope because it will be reviewed in the rechartering process. If we meet in SF and have good proposals, I encourage us to start work on recharter immediately afterwards.

After much playing around with acronyms, *someone* has a problem with every proposal, so I've elected in this PR to stop being cute and simply calling it the Congestion working group. Everyone knows what that means.